### PR TITLE
Fix regex for matching server version

### DIFF
--- a/drivers/python/rethinkdb/_backup.py
+++ b/drivers/python/rethinkdb/_backup.py
@@ -79,7 +79,7 @@ def check_minimum_version(progress, conn, minimum_version):
     parsed_version = None
     try:
         version = r.db('rethinkdb').table('server_status')[0]['process']['version'].run(conn)
-        matches = re.match('rethinkdb (\d+)\.(\d+)\.(\d+)\-', version)
+        matches = re.match('rethinkdb (\d+)\.(\d+)\.(\d+)', version)
         if matches == None:
             raise RuntimeError("invalid version string format")
         parsed_version = tuple(int(num) for num in matches.groups())


### PR DESCRIPTION
Regex matched on the hyphen and not the server version. Additionally, Ubuntu server version is absent of a hyphen and instead is in the form `rethinkdb 2.0.0+1~0trusty (GCC 4.8.2)`